### PR TITLE
Bump golang version

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -60,7 +60,7 @@
         name: goreleaser_github_token
     nodeset: fedora-pod
     vars:
-      go_version: "1.15"
+      go_version: "1.16.3"
 
 - job:
     name: tox-functional


### PR DESCRIPTION
Add possibility to create releases for mac on arm6

Set golang same as here https://github.com/opentelekomcloud-infra/otc-zuul-jobs/blob/master/zuul.d/go-jobs.yaml

PS: Forgot to do it earlier