### PR TITLE
Add publish docs job

### DIFF
--- a/playbooks/docs/fetch.yaml
+++ b/playbooks/docs/fetch.yaml
@@ -1,0 +1,16 @@
+- hosts: all
+  tasks:
+    - name: Fetch sphinx tarball
+      include_role:
+        name: fetch-sphinx-tarball
+      when: zuul_success | bool
+
+- hosts: localhost
+  tasks:
+    - name: Move fetched files to where upload is going to search for them
+      command: "cp -av {{ item }} {{ zuul.executor.work_root }}"
+      with_items:
+        - "{{ zuul.executor.log_root }}/docs-html.tar.gz*"
+        - "{{ zuul.executor.log_root }}/pdf/*"
+      when: pdf_files.matched > 0
+      failed_when: false

--- a/playbooks/docs/pre.yaml
+++ b/playbooks/docs/pre.yaml
@@ -1,0 +1,11 @@
+- hosts: all
+  roles:
+    - role: bindep
+      bindep_profile: doc
+    - role: ensure-tox
+    - role: ensure-sphinx
+      doc_building_packages:
+        - sphinx
+    - role: prepare-build-pdf-docs
+      when: not tox_skip_pdf
+    - revoke-sudo

--- a/playbooks/docs/run.yaml
+++ b/playbooks/docs/run.yaml
@@ -1,0 +1,28 @@
+- hosts: localhost
+  tasks:
+    - name: Check execution context
+      when: "zuul.branch is not defined"
+      fail:
+        msg: "This playbook must be run in a branch-based pipeline (e.g., 'promote')."
+
+- hosts: all
+  roles:
+    - role: ensure-if-python
+      # docs do not need the package itself to be installed
+      install_package: false
+    - role: tox
+      tox_envlist: docs
+      bindep_profile: compile doc
+    - role: build-pdf-docs
+      when: not tox_skip_pdf
+    - role: fetch-sphinx-tarball
+
+- hosts: localhost
+  tasks:
+    - name: Move fetched files to where upload is going to search for them
+      command: "cp -av {{ item }} {{ zuul.executor.work_root }}"
+      with_items:
+        - "{{ zuul.executor.log_root }}/docs-html.tar.gz*"
+        - "{{ zuul.executor.log_root }}/pdf/*"
+      when: pdf_files.matched > 0
+      failed_when: false

--- a/playbooks/publish/upload-to-swift.yaml
+++ b/playbooks/publish/upload-to-swift.yaml
@@ -18,6 +18,44 @@
 
   tasks:
     - block:
+
+        - name: Find PDF files
+          find:
+            paths: "{{ zuul.executor.work_root }}/"
+            file_type: file
+            patterns: "*.pdf"
+          register: pdf_files
+
+        # If we have PDF we want to add it into the artifacts archive and upload at once
+        # For this unpack>add>archive
+        - name: Create working directory
+          file:
+            path: "{{ zuul.executor.work_root }}/docs"
+            state: directory
+            mode: 0755
+          when: pdf_files.matched > 0
+
+        - name: Extract docs archive
+          vars:
+            findme:
+              - "{{ zuul.executor.work_root }}/docs-html.tar.bz2"
+              - "{{ zuul.executor.work_root }}/docs-html.tar.gz"
+          unarchive:  # noqa 208
+            src: "{{ lookup('first_found', findme) }}"
+            dest: "{{ zuul.executor.work_root }}/docs"
+          when: pdf_files.matched > 0
+
+        - name: Move found PDF file into doc dir
+          command: "mv {{ item.path }} {{ zuul.executor.work_root }}/docs"
+          with_items: "{{ pdf_files.files }}"
+          when: pdf_files.matched > 0
+
+        - name: Archive Docs - now with PDF inside
+          command: "tar -f docs-html.tar.gz -C {{ zuul_work_dir }}/docs --exclude=.doctrees -cz ."
+          args:
+            warn: false
+          when: pdf_files.matched > 0
+
         - name: Get cloud config from vault
           no_log: true
           vault_cloud_config:

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -393,3 +393,16 @@
         name: vault_data
       - secret: zuul_eco_project_config_docs_hc
         name: promote_data
+
+- job:
+    name: publish-otc-docs-hc
+    parent: otc-promote-docs-hc-base
+    description: |
+      Publish the docs to Swift.
+      This job is building Docs from scratch and it intended to
+      be executed in manual/periodic pipeline.
+    final: true
+    pre-run: playbooks/docs/pre.yaml
+    run: playbooks/docs/run.yaml
+    vars:
+      sphinx_python: python3

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -77,6 +77,9 @@
     promote:
       jobs:
         - promote-otc-tox-docs-hc
+    periodic:
+      jobs:
+        - publish-otc-docs-hc
 
 - project-template:
     name: api-ref-jobs


### PR DESCRIPTION
Idea is that from time to time we might need to rebuild all docs.
Instead of proposing dummy changes in every project we might trigger
rebuild of those based on the lastest state of their branch.
