### PR TITLE
Add proper fetch for docs

### DIFF
--- a/playbooks/docs/fetch.yaml
+++ b/playbooks/docs/fetch.yaml
@@ -5,12 +5,10 @@
         name: fetch-sphinx-tarball
       when: zuul_success | bool
 
-- hosts: localhost
-  tasks:
-    - name: Move fetched files to where upload is going to search for them
-      command: "cp -av {{ item }} {{ zuul.executor.work_root }}"
-      with_items:
-        - "{{ zuul.executor.log_root }}/docs-html.tar.gz*"
-        - "{{ zuul.executor.log_root }}/pdf/*"
-      when: pdf_files.matched > 0
-      failed_when: false
+    - name: Fetch archive
+      fetch:
+        dest: "{{ zuul.executor.work_root }}/"
+        src: "{{ ansible_user_dir }}/zuul-output/logs/docs-html.tar.gz"
+        flat: "true"
+      when: zuul_success | bool
+    #TODO: fetch PDF files

--- a/playbooks/docs/run.yaml
+++ b/playbooks/docs/run.yaml
@@ -15,15 +15,3 @@
       bindep_profile: compile doc
     - role: build-pdf-docs
       when: not tox_skip_pdf
-    - role: fetch-sphinx-tarball
-
-- hosts: localhost
-  tasks:
-    - name: Move fetched files to where upload is going to search for them
-      command: "cp -av {{ item }} {{ zuul.executor.work_root }}"
-      with_items:
-        - "{{ zuul.executor.log_root }}/docs-html.tar.gz"
-        - "{{ zuul.executor.log_root }}/pdf/*.pdf"
-        - "{{ ansible_user_dir }}/zuul-output/docs-html.tar.gz"
-        - "{{ ansible_user_dir }}/zuul-output/pdf/*.pdf"
-      failed_when: false

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -413,6 +413,7 @@
     nodeset: fedora-pod
     pre-run: playbooks/docs/pre.yaml
     run: playbooks/docs/run.yaml
+    post-run: playbooks/docs/fetch.yaml
     vars:
       sphinx_python: python3
       tox_envlist: docs


### PR DESCRIPTION
We can not copy the files, because they are not on the localhost.
fetch-sphinx-tarball role is not necessarily delivering what you request
to localhost, but instead place them into known location remotely.
