### PR TITLE
Drop building json as separate job from templates

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -55,13 +55,9 @@
     check:
       jobs:
         - otc-tox-docs
-        - build-otc-sphinx-json:
-            voting: false
     gate:
       jobs:
         - otc-tox-docs
-        - build-otc-sphinx-json:
-            voting: false
     promote:
       jobs:
         - promote-otc-tox-docs
@@ -75,13 +71,9 @@
     check:
       jobs:
         - otc-tox-docs
-        - build-otc-sphinx-json:
-            voting: false
     gate:
       jobs:
         - otc-tox-docs
-        - build-otc-sphinx-json:
-            voting: false
     promote:
       jobs:
         - promote-otc-tox-docs-hc
@@ -107,14 +99,10 @@
               - tox.ini
               - .zuul.yaml
               - zuul.yaml
-        - build-otc-sphinx-json:
-            voting: false
     gate:
       jobs:
         - build-otc-api-ref:
             files: *api-ref-triggers
-        - build-otc-sphinx-json:
-            voting: false
     promote:
       jobs:
         - promote-api-ref:
@@ -138,14 +126,10 @@
               - tox.ini
               - .zuul.yaml
               - zuul.yaml
-        - build-otc-sphinx-json:
-            voting: false
     gate:
       jobs:
         - build-otc-api-ref:
             files: *api-ref-hc-triggers
-        - build-otc-sphinx-json:
-            voting: false
     promote:
       jobs:
         - promote-api-ref-hc:
@@ -167,14 +151,10 @@
               - tox.ini
               - .zuul.yaml
               - zuul.yaml
-        - build-otc-sphinx-json:
-            voting: false
     gate:
       jobs:
         - build-otc-umn:
             files: *docs-umn-triggers
-        - build-otc-sphinx-json:
-            voting: false
     promote:
       jobs:
         - promote-umn:
@@ -196,14 +176,10 @@
               - tox.ini
               - .zuul.yaml
               - zuul.yaml
-        - build-otc-sphinx-json:
-            voting: false
     gate:
       jobs:
         - build-otc-umn:
             files: *docs-umn-hc-triggers
-        - build-otc-sphinx-json:
-            voting: false
     promote:
       jobs:
         - promote-umn-hc:


### PR DESCRIPTION
Building json as separate job is suboptimal. Instead processing for the
search functionality will be shifted to doc building jobs themselves.
