### PR TITLE
Revert "rollback not to override nodeset for tox-functional"

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -78,6 +78,7 @@
       - playbooks/otc/functest-pre.yaml
     post-run: playbooks/otc/functest-post.yaml
     ansible-version: 5
+    nodeset: ubuntu-jammy
     vars:
       vault_functional_cloud_secret_name: "clouds/otcci_functional"
       functest_project_name: "eu-de_zuul_otce"


### PR DESCRIPTION
Reverts opentelekomcloud-infra/zuul-project-config#90

Proven that this is caused by that. Apparently for a long running jobs Zuul somehow looses info when executing in another K8