### PR TITLE
Add promote for build-sphinx-docs job

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -259,6 +259,21 @@
       make_public: true
 
 - job:
+    name: promote-otc-sphinx-docs-hc
+    parent: otc-promote-docs-hc-base
+    description: |
+      Promote content from build-sphinx-docs job for projects that
+      run tox using the docs environment following Open Telekom Cloud PTI.
+      Publish the results of the docs tox job to
+      SWIFT/{{ zuul.project.short_name }}.
+      This is the promote job for ``build-sphinx-docs``.
+    final: true
+    vars:
+      download_artifact_job: "build-sphinx-docs"
+      prefix: ""
+      make_public: true
+
+- job:
     name: promote-api-ref
     parent: otc-promote-docs-base
     description: |


### PR DESCRIPTION
Since we are not really able to modify vars of the final jobs we need to
build a job variant that explicitly wants to publish build-sphinx-docs
artifacts.
