### PR TITLE
Switch ansible functests to new way

### DIFF
--- a/zuul.d/functest-jobs.yaml
+++ b/zuul.d/functest-jobs.yaml
@@ -187,3 +187,57 @@
     vars:
       functest_candidate_clouds:
         - "cloud_41245_nl_functest4"
+
+- job:
+    name: otc-ansible-collection-test-integration-de
+    parent: ansible-collection-test-integration
+    description: |
+      Execute ansible-test integration tests for the collection with provided
+      cloud in EU-DE region
+    pre-run:
+      - playbooks/functest/pre.yaml
+    post-run: playbooks/functest/post.yaml
+    # Until we solve networking issue between 2 K8 cluster we need to have it
+    # on a VM
+    nodeset: ubuntu-jammy
+    vars:
+      functest_candidate_clouds:
+        - "cloud_41245_de_functest1"
+        - "cloud_41245_de_functest2"
+        - "cloud_41245_de_functest3"
+        - "cloud_41245_de_functest4"
+      tox_envlist: functional
+      tox_environment:
+        OS_CLOUD: functional_user
+        OS_ADMIN_CLOUD: functional_user
+    secrets:
+      - secret: zuul_eco_project_config_vault_new
+        name: vault_data
+    semaphores: functest-eu-de
+
+- job:
+    name: otc-ansible-collection-test-integration-nl
+    parent: ansible-collection-test-integration
+    description: |
+      Execute ansible-test integration tests for the collection with provided
+      cloud in EU-NL region
+    pre-run:
+      - playbooks/functest/pre.yaml
+    post-run: playbooks/functest/post.yaml
+    # Until we solve networking issue between 2 K8 cluster we need to have it
+    # on a VM
+    nodeset: ubuntu-jammy
+    vars:
+      functest_candidate_clouds:
+        - "cloud_41245_nl_functest1"
+        - "cloud_41245_nl_functest2"
+        - "cloud_41245_nl_functest3"
+        - "cloud_41245_nl_functest4"
+      tox_envlist: functional
+      tox_environment:
+        OS_CLOUD: functional_user
+        OS_ADMIN_CLOUD: functional_user
+    secrets:
+      - secret: zuul_eco_project_config_vault_new
+        name: vault_data
+    semaphores: functest-eu-nl

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -70,26 +70,6 @@
       vault_github_token_path: "github_zuul/token"
 
 - job:
-    name: otc-ansible-collection-test-integration
-    parent: ansible-collection-test-integration
-    description: |
-      Execute ansible-test integration tests for the collection with provided cloud
-    pre-run:
-      - playbooks/otc/functest-pre.yaml
-    post-run: playbooks/otc/functest-post.yaml
-    # Until we solve networking issue between 2 K8 cluster we need to have it
-    # on a VM
-    nodeset: ubuntu-jammy
-    vars:
-      vault_functional_cloud_secret_name: "clouds/otcci_functional"
-      functest_project_name: eu-de_zuul_acc
-      ansible_test_integration_env:
-        OS_CLOUD: functest_cloud
-    secrets:
-      - secret: zuul_project_config_vault
-        name: zuul_project_config_vault
-
-- job:
     name: otcinfra-upload-image
     parent: upload-docker-image
     secrets:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -28,7 +28,7 @@
         - ansible-collection-test-sanity
         - ansible-collection-test-units
         - ansible-collection-docs
-        - otc-ansible-collection-test-integration
+        - otc-ansible-collection-test-integration-de
     gate:
       jobs:
         - otc-tox-pep8
@@ -38,7 +38,7 @@
         - ansible-collection-test-sanity
         - ansible-collection-test-units
         - ansible-collection-docs
-        - otc-ansible-collection-test-integration
+        - otc-ansible-collection-test-integration-de
     release:
       jobs:
         - release-ansible-collection


### PR DESCRIPTION
Do same thing for ansible as we do for other functests to keep
consistency and have project cleanup running.
