### PR TITLE
Revert "Adding post-timeout for helpcenter base jobs due to timeouts when fil…"

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -115,23 +115,19 @@
         - otc-tox-docs:
             files:
               - ^doc/.*
-            post-timeout: 3600
     gate:
       jobs:
         - otc-tox-docs:
             files:
               - ^doc/.*
-            post-timeout: 3600
     promote:
       jobs:
         - promote-otc-tox-docs-hc:
             files:
               - ^doc/.*
-            post-timeout: 3600
     periodic:
       jobs:
-        - publish-otc-docs-hc:
-            post-timeout: 3600
+        - publish-otc-docs-hc
 
 - project-template:
     name: api-ref-jobs


### PR DESCRIPTION
Reverts opentelekomcloud-infra/zuul-project-config#122

Date of merge is exactly the date from which certain jobs stopped working with complain in zuul
```
 Exception: Unable to modify final job <Job publish-otc-docs-hc branches: None source: opentelekomcloud-infra/base-jobs/zuul.d/jobs.yaml@main#25> attribute post_timeout=3600 with variant <Job publish-otc-docs-hc branches: None source: opentelekomcloud-infra/zuul-project-config/zuul.d/project-templates.yaml@main#109>
2023-01-18 13:10:14,176 INFO zuul.Pipeline.eco.periodic: Reporting item <QueueItem f46feb569fd447c7b30721ee42a22b2a for <Branch 0x7f74a0445c00 opentelekomcloud-docs/resource-management-service creates refs/heads/main on bc010b1ad80ea0d1460305ac06defbcb48a751ab> in periodic>, actions: [<zuul.driver.smtp.smtpreporter.SMTPReporter object at 0x7f74dc4c6260>]
```

Once we see some jobs failing on post (what should not be the case anymore with improved performance in swift) we should rather set this is the job itself and not the template