### PR TITLE
Limit amount of parallel publish jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,4 +1,9 @@
 ---
+- semaphore:
+    # We do not want to make a big stress on the system and only allow max of 10 jobs at a time
+    name: docs-build
+    max: 10
+
 - job:
     name: release-python
     description: |
@@ -391,6 +396,8 @@
     post-run:
       - playbooks/docs/fetch.yaml
     nodeset: ubuntu-jammy
+    semaphores:
+      - docs-build
     vars:
       sphinx_python: python3
       tox_envlist: docs


### PR DESCRIPTION
When mass doc rebuild is happening we are generating quite a load on storage. Reduce this by limiting amount of parallel jobs