### PR TITLE
Skip non HC docs from search

### DIFF
--- a/playbooks/publish/docs.yaml
+++ b/playbooks/publish/docs.yaml
@@ -132,6 +132,9 @@
                 - "indexes is defined"
                 - "indexes.matched > 0"
           ignore_errors: true
+          when:
+            - "publish_doc_to_search is defined"
+            - "publish_doc_to_search"
 
         - name: Destroy vault token
           include_role:

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -131,6 +131,7 @@
     post-run: playbooks/publish/docs.yaml
     vars:
       write_root_marker: true
+      publish_doc_to_search: false
     nodeset:
       nodes: []
     secrets:
@@ -170,6 +171,7 @@
     vars:
       container: "{{ zuul.project.short_name }}"
       write_root_marker: true
+      publish_doc_to_search: true
     nodeset:
       nodes: []
     secrets:


### PR DESCRIPTION
We currently include all docs that we build in the search of HC. This is
not good. Solve this by wrapping search publish block with additional
conditions and set publish flag on HC base job.
