### PR TITLE
feat(jobs): Create stackmon dedicated image upload job

### DIFF
--- a/playbooks/image/post.yaml
+++ b/playbooks/image/post.yaml
@@ -27,7 +27,7 @@
       no_log: true
       delegate_to: localhost
       ansible.builtin.uri:
-        url: "{{ vault_addr }}/v1/secret/data/image_registries"
+        url: "{{ vault_addr }}/v1/secret/data/{{ vault_path | default('image_registries') }}"
         method: "GET"
         headers:
           "X-Vault-Token": "{{ lookup('file', vault_token_dest) }}"
@@ -53,7 +53,7 @@
         return_content: true
       register: dt_credentials
       failed_when: false
-      when: 
+      when:
         - "zuul_bom_results is defined"
 
     - name: Upload BOMs to dependency track
@@ -63,7 +63,7 @@
         dependencytrack_credentials: "{{ dt_credentials.json.data.data }}"
         bom_artifacts: "{{ zuul_bom_results }}"
       when: "zuul_bom_results is defined"
-      when: 
+      when:
         - "zuul_bom_results is defined"
         - "dt_credentials is defined"
         - "dt_credentials.json is defined"

--- a/zuul.d/container-jobs.yaml
+++ b/zuul.d/container-jobs.yaml
@@ -30,11 +30,23 @@
     name: otcinfra-upload-container-images
     parent: otc-build-container-image
     description: |
-      Upload image(s) to the registry. 
+      Upload image(s) to the registry.
 
       Please refer to the upload-container-image role.
     nodeset: ubuntu-jammy
     post-run: playbooks/image/post.yaml
+    vars:
+      vault_path: image_registries
     secrets:
       - secret: zuul_eco_project_config_vault_new
         name: vault_data
+
+- job:
+    name: stackmon-upload-container-images
+    parent: otcinfra-upload-container-images
+    description: |
+      Upload StackMon image(s) to the registry.
+
+      Please refer to the upload-container-image role.
+    vars:
+      vault_path: stackmon_quay


### PR DESCRIPTION
Quay require separate creds per organization. To upload to stackmon
organization we need to have dedicated job. This is implemented by
making vault path configurable.
