### PR TITLE
chore(ci): Cleanup also log_root for docs publish

### DIFF
--- a/playbooks/publish/docs.yaml
+++ b/playbooks/publish/docs.yaml
@@ -159,6 +159,8 @@
       loop:
         - "{{ zuul.executor.work_root }}/docs"
         - "{{ zuul.executor.work_root }}/docs-json"
+        - "{{ zuul.executor.log_root }}/docs"
+        - "{{ zuul.executor.log_root }}/docs-json"
       loop_control:
         loop_var: zj_item
       when: zuul_success | bool


### PR DESCRIPTION
Apparently unpackaged docs are present in too many places. Add also cleanup in log_root