### PR TITLE
Drop zuul-output content in doc publish jobs

### DIFF
--- a/playbooks/publish/docs.yaml
+++ b/playbooks/publish/docs.yaml
@@ -161,6 +161,7 @@
         - "{{ zuul.executor.work_root }}/docs-json"
         - "{{ zuul.executor.log_root }}/docs"
         - "{{ zuul.executor.log_root }}/docs-json"
+        - "{{ ansible_user_dir }}/zuul-output"
       loop_control:
         loop_var: zj_item
       when: zuul_success | bool


### PR DESCRIPTION
There are apparently still unpacked htmls laying around. zuul job fetching this (https://opendev.org/zuul/zuul-jobs/src/branch/master/roles/fetch-output/tasks/main.yaml#L24) is fetching content from following locations:

- "{{ ansible_user_dir }}/zuul-output"
- "{{ zuul.executor.work_root }}/artifacts"
- "{{ zuul.executor.work_root }}/docs"