### PR TITLE
Precise the purge from zuul-output in publish jobs

### DIFF
--- a/playbooks/publish/docs.yaml
+++ b/playbooks/publish/docs.yaml
@@ -161,7 +161,8 @@
         - "{{ zuul.executor.work_root }}/docs-json"
         - "{{ zuul.executor.log_root }}/docs"
         - "{{ zuul.executor.log_root }}/docs-json"
-        - "{{ ansible_user_dir }}/zuul-output"
+        - "{{ ansible_user_dir }}/zuul-output/docs"
+        - "{{ ansible_user_dir }}/zuul-output/docs-json"
       loop_control:
         loop_var: zj_item
       when: zuul_success | bool


### PR DESCRIPTION
Be more precise in what to purge from zuul-output since apparently dropping zuul-output causes also drop of necessary folders underneath