### PR TITLE
Add eu-ch cleanup jobs to periodic-hourly pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -225,6 +225,8 @@
         merged: true
       gitlab:
         merged: true
+      gitea:
+        merged: true
     trigger:
       github:
         - event: pull_request
@@ -232,6 +234,17 @@
       gitlab:
          - event: gl_merge_request
            action: merged
+      gitea:
+        - event: gt_pull_request
+          action: closed
+    success:
+      gitea:
+        comment: true
+        status: "success"
+    failure:
+      gitea:
+        comment: true
+        status: "failure"
 
 - pipeline:
     name: pre-release

--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -225,8 +225,6 @@
         merged: true
       gitlab:
         merged: true
-      gitea:
-        merged: true
     trigger:
       github:
         - event: pull_request
@@ -234,17 +232,6 @@
       gitlab:
          - event: gl_merge_request
            action: merged
-      gitea:
-        - event: gt_pull_request
-          action: closed
-    success:
-      gitea:
-        comment: true
-        status: "success"
-    failure:
-      gitea:
-        comment: true
-        status: "failure"
 
 - pipeline:
     name: pre-release

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -32,3 +32,7 @@
         - otc-project-cleanup-eu-nl-functest2
         - otc-project-cleanup-eu-nl-functest3
         - otc-project-cleanup-eu-nl-functest4
+        - otc-project-cleanup-eu-ch-functest1
+        - otc-project-cleanup-eu-ch-functest2
+        - otc-project-cleanup-eu-ch-functest3
+        - otc-project-cleanup-eu-ch-functest4


### PR DESCRIPTION
The eu-ch functest cleanup job definitions (functest1-4) already exist in functest-jobs.yaml but were never added to the periodic-hourly pipeline in projects.yaml.

This caused router quota exhaustion in eu-ch functest projects from leaked test resources, making all eu-ch integration tests that require routers fail consistently (dns_private, nat, vpc, vpc_peering, vpc_route, vpn).

**Fix:** Add the 4 eu-ch cleanup jobs to the periodic-hourly pipeline so they run hourly like eu-de and eu-nl.